### PR TITLE
Add OTA id

### DIFF
--- a/watermeterkit.yaml
+++ b/watermeterkit.yaml
@@ -22,7 +22,8 @@ logger:
 api:
 
 ota:
-  - platform: esphome
+  - id: ota_std
+    platform: esphome
   
 dashboard_import:
   package_import_url: github://smarthomeshop/watermeterkit/watermeterkit.yaml@main


### PR DESCRIPTION
This allows consumers to override the OTA definition, for example to configure a password.

Without this change, the following configuration will triggered `Only one instance of the esphome ota platform is allowed per port. Note that this error may result from OTA specified in packages.`:

```yaml
ota:
  - platform: esphome
    password: !secret ota_password
```

With this change, you can extend the OTA definition by referencing it through its id:

```yaml
ota:
  - id: !extend ota_std
    password: !secret ota_password
```